### PR TITLE
Update init_state.cpp in lua_api [issue 50]

### DIFF
--- a/iolite_plugins/lua_plugin/init_state.cpp
+++ b/iolite_plugins/lua_plugin/init_state.cpp
@@ -895,6 +895,13 @@ void script_init_state(sol::state& s)
   s["Variant"]["from_uint"] = [](uint32_t value) {
     return io_base->variant_from_uint(value);
   };
+  // @function from_uint8
+  // @summary Creates a new variant storing a single 8bit unsigned integer value.
+  // @param value number The unsigned 8bit integer value to set.
+  // @return Variant value The new variant.
+  s["Variant"]["from_uint8"] = [](uint8_t value) {
+    return io_base->variant_from_uint8(value);
+  };
   // @function from_string
   // @summary Creates a new variant storing a string.
   // @param value string The string to set.


### PR DESCRIPTION
Added an additional function to allow setting uint8 variables for variant type.

This is a request fix for an issue highlighted here:
https://github.com/MissingDeadlines/iolite/issues/50

please note I did not compile and test the fix. I am presuming uint8_t should exist from the same header for variable type uint32_t used in the variant.from_uint function.